### PR TITLE
Fix "main" files reference to chosen.min.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "bowerJSON":{
     "main": [
       "chosen.jquery.min.js",
-      "chosen.css",
+      "chosen.min.css",
       "chosen-sprite@2x.png",
       "chosen-sprite.png"
     ]


### PR DESCRIPTION
`chosen.css`, which is currently referenced in the "main" section of package.json, does not exist in the bower repo.  This fixes tools like bowerMainFiles that operate on the list of main files.

The bower.json file in https://github.com/harvesthq/bower-chosen is what needs to be updated, but I think this was the place I should have done the update and the next release will pick it up.
